### PR TITLE
[feat] 주문 생성 Web계층 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
@@ -37,6 +37,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
 
     // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/dev/chan/orderpaymentservice/application/dto/PlaceOrderCommand.java
+++ b/src/main/java/dev/chan/orderpaymentservice/application/dto/PlaceOrderCommand.java
@@ -1,8 +1,14 @@
 package dev.chan.orderpaymentservice.application.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record PlaceOrderCommand(
-        long memberId,
+        Long memberId,
         Long productId,
         int orderQuantity
 
-) {}
+) {
+    public static PlaceOrderCommand of(@NotBlank Long memberId, @NotBlank Long productId, int orderQuantity) {
+        return new PlaceOrderCommand(memberId,productId,orderQuantity);
+    }
+}

--- a/src/main/java/dev/chan/orderpaymentservice/common/ApiError.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/ApiError.java
@@ -1,5 +1,27 @@
 package dev.chan.orderpaymentservice.common;
 
-public record ApiError(int status, String code, String message) {
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+public class ApiError {
+
+    int status;
+    String code;
+    String message;
+    List<ErrorDetail> details;
+
+    public ApiError(int status, String code, String message) {
+        this(status, code, message, null);
+    }
+
+    public ApiError(int status, String code, String message, List<ErrorDetail> details) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.details = Ensure.notEmpty(List.copyOf(details), "ApiError.details") ;
+
+    }
 
 }

--- a/src/main/java/dev/chan/orderpaymentservice/common/ApiError.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/ApiError.java
@@ -1,0 +1,5 @@
+package dev.chan.orderpaymentservice.common;
+
+public record ApiError(int status, String code, String message) {
+
+}

--- a/src/main/java/dev/chan/orderpaymentservice/common/ApiResponse.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/ApiResponse.java
@@ -1,5 +1,13 @@
 package dev.chan.orderpaymentservice.common;
 
+/**
+ * API 공통 응답 DTO
+ * @param success - 성공/실패 여부
+ * @param message - 성공 메시지
+ * @param data - 성공시 응답 데이터
+ * @param error - 실패시 예외 세부 정보
+ * @param <T>
+ */
 public record ApiResponse<T> (
         boolean success,
         String message,
@@ -7,11 +15,36 @@ public record ApiResponse<T> (
         ApiError error)
 {
 
+    /**
+     * 성공 응답
+     * @param data - 예외 데이터
+     * @return ApiResponse<T> - 공통 응답 DTO
+     * @param <T> - 예외 타입
+     */
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, null , data, null);
+        return new ApiResponse<>(true, null, data, null);
     }
 
-    public static <T> ApiResponse<T> failure(T data, ApiError error) {
+    /**
+     * 데이터 없는 실패
+     * @param error - API 예외 응답 정보
+     * @return ApiResponse<T>
+     */
+    public static <T> ApiResponse<T> failure(ApiError error) {
         return new ApiResponse<>(false,null, null, error);
     }
+
+    /**
+     * 데이터가 필요한 실패
+     *
+     * @param data - 예외 세부 정보
+     * @param error - API 예외 응답 정보
+     * @return ApiResponse<T>
+     */
+    public static <T> ApiResponse<T> failure(T data, ApiError error) {
+        return new ApiResponse<>(false, null, data, error);
+    }
+
+
+
 }

--- a/src/main/java/dev/chan/orderpaymentservice/common/ApiResponse.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/ApiResponse.java
@@ -1,0 +1,17 @@
+package dev.chan.orderpaymentservice.common;
+
+public record ApiResponse<T> (
+        boolean success,
+        String message,
+        T data,
+        ApiError error)
+{
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, null , data, null);
+    }
+
+    public static <T> ApiResponse<T> failure(T data, ApiError error) {
+        return new ApiResponse<>(false,null, null, error);
+    }
+}

--- a/src/main/java/dev/chan/orderpaymentservice/common/CommonError.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/CommonError.java
@@ -1,0 +1,22 @@
+package dev.chan.orderpaymentservice.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Accessors(fluent = true)
+@RequiredArgsConstructor
+public enum CommonError implements ErrorCode{
+
+    ARGUMENT_ERROR(HttpStatus.BAD_REQUEST,"COMMON-INVALID_ARGUMENT", "common.errors.invalid_argument");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String messageKey;
+
+
+
+
+}

--- a/src/main/java/dev/chan/orderpaymentservice/common/ErrorDetail.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/ErrorDetail.java
@@ -1,0 +1,5 @@
+package dev.chan.orderpaymentservice.common;
+
+public record ErrorDetail(String key, String message) {
+
+}

--- a/src/main/java/dev/chan/orderpaymentservice/common/PolicyViolationException.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/PolicyViolationException.java
@@ -7,7 +7,7 @@ import lombok.Getter;
  * 도메인 예외 추가시 반드시 이 클래스를 상속해주세요.
  */
 @Getter
-public class PolicyViolationException extends RuntimeException{
+public class PolicyViolationException extends RuntimeException {
     private final ErrorCode errorCode;
     private final String message;
 

--- a/src/main/java/dev/chan/orderpaymentservice/web/OrderController.java
+++ b/src/main/java/dev/chan/orderpaymentservice/web/OrderController.java
@@ -20,7 +20,7 @@ public class OrderController {
     private final PlaceOrderUseCase placeOrderUseCase;
 
     @PostMapping
-    public ResponseEntity<?> placeOrder(@RequestBody PlaceOrderRequest req) {
+    public ResponseEntity<ApiResponse<OrderResult>> placeOrder(@RequestBody PlaceOrderRequest req) {
         OrderResult result = placeOrderUseCase.handle(PlaceOrderCommand.of(
                 req.getMemberId(),
                 req.getProductId(),

--- a/src/main/java/dev/chan/orderpaymentservice/web/OrderController.java
+++ b/src/main/java/dev/chan/orderpaymentservice/web/OrderController.java
@@ -5,6 +5,7 @@ import dev.chan.orderpaymentservice.application.dto.OrderResult;
 import dev.chan.orderpaymentservice.application.dto.PlaceOrderCommand;
 import dev.chan.orderpaymentservice.common.ApiResponse;
 import dev.chan.orderpaymentservice.web.dto.PlaceOrderRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,7 +21,7 @@ public class OrderController {
     private final PlaceOrderUseCase placeOrderUseCase;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<OrderResult>> placeOrder(@RequestBody PlaceOrderRequest req) {
+    public ResponseEntity<ApiResponse<OrderResult>> placeOrder(@Valid @RequestBody PlaceOrderRequest req) {
         OrderResult result = placeOrderUseCase.handle(PlaceOrderCommand.of(
                 req.getMemberId(),
                 req.getProductId(),

--- a/src/main/java/dev/chan/orderpaymentservice/web/OrderController.java
+++ b/src/main/java/dev/chan/orderpaymentservice/web/OrderController.java
@@ -1,0 +1,33 @@
+package dev.chan.orderpaymentservice.web;
+
+import dev.chan.orderpaymentservice.application.PlaceOrderUseCase;
+import dev.chan.orderpaymentservice.application.dto.OrderResult;
+import dev.chan.orderpaymentservice.application.dto.PlaceOrderCommand;
+import dev.chan.orderpaymentservice.common.ApiResponse;
+import dev.chan.orderpaymentservice.web.dto.PlaceOrderRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/orders")
+public class OrderController {
+
+    private final PlaceOrderUseCase placeOrderUseCase;
+
+    @PostMapping
+    public ResponseEntity<?> placeOrder(@RequestBody PlaceOrderRequest req) {
+        OrderResult result = placeOrderUseCase.handle(PlaceOrderCommand.of(
+                req.getMemberId(),
+                req.getProductId(),
+                req.getOrderQuantity())
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+
+    }
+}

--- a/src/main/java/dev/chan/orderpaymentservice/web/common/GlobalExceptionHandler.java
+++ b/src/main/java/dev/chan/orderpaymentservice/web/common/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package dev.chan.orderpaymentservice.web.common;
+
+import dev.chan.orderpaymentservice.common.ApiError;
+import dev.chan.orderpaymentservice.common.ApiResponse;
+import dev.chan.orderpaymentservice.common.ErrorCode;
+import dev.chan.orderpaymentservice.common.PolicyViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+    /**
+     * 정책 위반 예외 핸들러
+     * 설명 - 정책 위반 예외에 대한 예외 처리 핸들러입니다.
+     * 공통응답 DTO (ApiResponse) 에 오류 정보(ApiError) 를 담아 클라이언트에 응답합니다.
+     *
+     * @param e - PolicyViolationException.class
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(PolicyViolationException.class)
+    public ResponseEntity<ApiResponse<ApiError>> handle(PolicyViolationException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        // TODO - messageKey 는 메시지 프로세스 개발 후 실제 메시지로 대체될 예정입니다.
+        ApiError apiError = new ApiError(errorCode.status().value(), errorCode.code(), errorCode.messageKey());
+
+        // TODO - 전역 예외처리가 늘어날 경우 공통 예외 응답 메서드로 분리 예정입니다.
+        return ResponseEntity.status(errorCode.status())
+                .body(ApiResponse.failure(apiError));
+
+    }
+}

--- a/src/main/java/dev/chan/orderpaymentservice/web/dto/PlaceOrderRequest.java
+++ b/src/main/java/dev/chan/orderpaymentservice/web/dto/PlaceOrderRequest.java
@@ -1,6 +1,6 @@
 package dev.chan.orderpaymentservice.web.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,13 +9,13 @@ import lombok.Getter;
 public class PlaceOrderRequest {
 
     // TODO! 테스트를 위해 임시적으로 MemberId를 요청 데이터에 담아 받습니다. 추후 JWT 활용하도록 변경 예정입니다.
-    @NotBlank
+    @NotNull
     private Long memberId;
 
-    @NotBlank
+    @NotNull
     private Long productId;
 
-    @NotBlank
+    @Positive
     private int orderQuantity;
 
 }

--- a/src/main/java/dev/chan/orderpaymentservice/web/dto/PlaceOrderRequest.java
+++ b/src/main/java/dev/chan/orderpaymentservice/web/dto/PlaceOrderRequest.java
@@ -1,9 +1,11 @@
 package dev.chan.orderpaymentservice.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class PlaceOrderRequest {
 
     // TODO! 테스트를 위해 임시적으로 MemberId를 요청 데이터에 담아 받습니다. 추후 JWT 활용하도록 변경 예정입니다.

--- a/src/main/java/dev/chan/orderpaymentservice/web/dto/PlaceOrderRequest.java
+++ b/src/main/java/dev/chan/orderpaymentservice/web/dto/PlaceOrderRequest.java
@@ -1,0 +1,19 @@
+package dev.chan.orderpaymentservice.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class PlaceOrderRequest {
+
+    // TODO! 테스트를 위해 임시적으로 MemberId를 요청 데이터에 담아 받습니다. 추후 JWT 활용하도록 변경 예정입니다.
+    @NotBlank
+    private Long memberId;
+
+    @NotBlank
+    private Long productId;
+
+    @NotBlank
+    private int orderQuantity;
+
+}


### PR DESCRIPTION


## 📌 관련 이슈
- close #9 

---

## 📝 작업 내용
> 주문 생성 Web 계층 구현 
- `OrderController` 궇녀 
- `GlobalExceptionHandler`구현 : 정책위반 예외 핸들러 추가 
- 공통 응답 DTO : `ApiResponse` 구현 
- 공통 예외 DTO : `API Error` 구현 

E2E 테스트를 위해 멤버가 product 등록 ->  등록된 product 조회 -> product에 대한 주문 생성 까지의 플로우가 필요한데, 현재 없으므로 
postman으로 진행했습니다. 추후 테스트 가능한 postman 링크를 추가해 공유 예정입니다. 

---

## ✅ 체크리스트 
- [ ] 응답 실패시 예외가 발생하나요? Controller  

## 🔍 추가 고려 사항 (추후 PR 예정)

- 요청 객체 필드 Bean Validation 추가 
- 주문 생성 워크플로우 테스트를 위한 UI 
- 제품생성 화면 
- 주문 조회 api 
- 예외 처리시 메시지 조회 프로세스 구현 
