### PR TITLE
[feat] 회원 조회 기능 및 예외 처리 구현

### DIFF
--- a/src/main/java/dev/chan/orderpaymentservice/application/auth/LoginUseCase.java
+++ b/src/main/java/dev/chan/orderpaymentservice/application/auth/LoginUseCase.java
@@ -19,7 +19,7 @@ public class LoginUseCase {
     public LoginResult handle(LoginCommand cmd){
         Member loginMember = memberRepository.findByEmail(cmd.email())
                 .filter(m -> m.isMatch(cmd.password()))
-                .orElseThrow(() -> new PolicyViolationException(MemberError.AUTHENTICATION_FAIL,"Invalid credentials"));
+                .orElseThrow(() -> new PolicyViolationException(MemberError.PASSWORD_MISMATCH,"Invalid credentials"));
 
         return LoginResult.of(loginMember);
     }

--- a/src/main/java/dev/chan/orderpaymentservice/application/member/GetMemberUseCase.java
+++ b/src/main/java/dev/chan/orderpaymentservice/application/member/GetMemberUseCase.java
@@ -1,0 +1,26 @@
+package dev.chan.orderpaymentservice.application.member;
+
+import dev.chan.orderpaymentservice.application.member.dto.MemberDetail;
+import dev.chan.orderpaymentservice.common.NotFoundException;
+import dev.chan.orderpaymentservice.domain.member.Member;
+import dev.chan.orderpaymentservice.domain.member.MemberError;
+import dev.chan.orderpaymentservice.domain.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetMemberUseCase {
+
+    private final MemberRepository memberRepository;
+
+    public MemberDetail handle(long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(MemberError.MEMBER_NOT_FOUND, "Member not found. id = [" + memberId + "]"));
+
+        return MemberDetail.of(member.getEmail(),member.getName(),member.getPhone());
+
+    }
+}

--- a/src/main/java/dev/chan/orderpaymentservice/application/member/dto/MemberDetail.java
+++ b/src/main/java/dev/chan/orderpaymentservice/application/member/dto/MemberDetail.java
@@ -1,0 +1,7 @@
+package dev.chan.orderpaymentservice.application.member.dto;
+
+public record MemberDetail(String email, String name, String phone) {
+    public static MemberDetail of(String email, String name, String phone) {
+        return new MemberDetail(email, name, phone);
+    }
+}

--- a/src/main/java/dev/chan/orderpaymentservice/common/ApiError.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/ApiError.java
@@ -20,7 +20,7 @@ public class ApiError {
         this.status = status;
         this.code = code;
         this.message = message;
-        this.details = Ensure.notEmpty(List.copyOf(details), "ApiError.details") ;
+        this.details = details;
 
     }
 

--- a/src/main/java/dev/chan/orderpaymentservice/common/DomainException.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/DomainException.java
@@ -1,0 +1,13 @@
+package dev.chan.orderpaymentservice.common;
+
+import lombok.Getter;
+
+@Getter
+public abstract class DomainException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    protected DomainException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/dev/chan/orderpaymentservice/common/NotFoundException.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/NotFoundException.java
@@ -1,0 +1,7 @@
+package dev.chan.orderpaymentservice.common;
+
+public class NotFoundException extends DomainException {
+    public NotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/dev/chan/orderpaymentservice/common/PolicyViolationException.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/PolicyViolationException.java
@@ -7,9 +7,7 @@ import lombok.Getter;
  * 도메인 예외 추가시 반드시 이 클래스를 상속해주세요.
  */
 @Getter
-public class PolicyViolationException extends RuntimeException {
-    private final ErrorCode errorCode;
-    private final String message;
+public class PolicyViolationException extends DomainException {
 
     /**
      * 도메인 정책 위반시 발생하는 최상위 예외
@@ -18,8 +16,6 @@ public class PolicyViolationException extends RuntimeException {
      * @param message - 예외 발생시 디버깅을 위한 시스템 메시지
      */
     public PolicyViolationException(ErrorCode errorCode, String message) {
-        super(message);
-        this.errorCode = errorCode;
-        this.message = message;
+        super(errorCode,message);
     }
 }

--- a/src/main/java/dev/chan/orderpaymentservice/common/UnauthorizedException.java
+++ b/src/main/java/dev/chan/orderpaymentservice/common/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package dev.chan.orderpaymentservice.common;
+
+/**
+ * 인증 실패시 예외
+ */
+public class UnauthorizedException extends DomainException {
+    public UnauthorizedException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/dev/chan/orderpaymentservice/domain/member/Member.java
+++ b/src/main/java/dev/chan/orderpaymentservice/domain/member/Member.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 public class Member {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @Column(unique = true, nullable = false)
     private String email;

--- a/src/main/java/dev/chan/orderpaymentservice/domain/member/MemberError.java
+++ b/src/main/java/dev/chan/orderpaymentservice/domain/member/MemberError.java
@@ -10,11 +10,13 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Accessors(fluent = true)
 public enum MemberError implements ErrorCode {
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "MEM-INVALID_PASSWORD","member.error.invalid_password"),
-    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "MEM-DUPLICATE_EMAIL" ,"member.duplicate_email" ),
-    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "MEM-INVALID_EMAIL" ,"member.invalid_email"),
-    AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED, "MEM-AUTHENTICATION_FAIL" ,"member.authentication_fail"),
+    INVALID_SESSION(HttpStatus.UNAUTHORIZED, "MEM-INVALID_SESSION" ,"member.error.invalid_session"),
+    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED,"MEM-PASSWORD_MISMATCH" ,"member.error.invalid_credentials" ),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MEM-UNAUTHORIZED" ,"member.error.unauthorized" ),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "MEM-DUPLICATE_EMAIL" ,"member.error.duplicate_email" ),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEM-NOT_FOUND", "member.error.not_found" ),
     ;
+
     private final HttpStatus status;
     private final String code;
     private final String messageKey;

--- a/src/main/java/dev/chan/orderpaymentservice/domain/order/Order.java
+++ b/src/main/java/dev/chan/orderpaymentservice/domain/order/Order.java
@@ -19,7 +19,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "ORDERS")
 public class Order {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private long id;
     private Long orderedBy;
 
     @CurrentTimestamp

--- a/src/main/java/dev/chan/orderpaymentservice/domain/product/Product.java
+++ b/src/main/java/dev/chan/orderpaymentservice/domain/product/Product.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 public class Product {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
     private String name;
 
     @Embedded

--- a/src/main/java/dev/chan/orderpaymentservice/web/api/ApiExceptionHandler.java
+++ b/src/main/java/dev/chan/orderpaymentservice/web/api/ApiExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -22,7 +23,7 @@ public class ApiExceptionHandler {
      * @param e - PolicyViolationException.class
      * @return ResponseEntity
      */
-    @org.springframework.web.bind.annotation.ExceptionHandler(PolicyViolationException.class)
+    @ExceptionHandler(PolicyViolationException.class)
     public ResponseEntity<ApiResponse<Void>> handle(PolicyViolationException e) {
         ErrorCode errorCode = e.getErrorCode();
 
@@ -35,12 +36,21 @@ public class ApiExceptionHandler {
 
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponse<Void>> handle(UnauthorizedException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        ApiError apiError = new ApiError(errorCode.status().value(), errorCode.code(), e.getMessage());
+        return ResponseEntity.status(errorCode.status())
+                .body(ApiResponse.failure(apiError));
+    }
+
     /**
      * bean validation 예외 핸들러
      * @param e - MethodArgumentNotValidException.class
      * @return ApiResponse<ApiError>
      */
-    @org.springframework.web.bind.annotation.ExceptionHandler(MethodArgumentNotValidException.class)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handle(MethodArgumentNotValidException e){
         List<ErrorDetail> details = e.getBindingResult().getAllErrors().stream().map(err -> {
             if (err instanceof FieldError fieldError) {

--- a/src/main/java/dev/chan/orderpaymentservice/web/api/MemberApiController.java
+++ b/src/main/java/dev/chan/orderpaymentservice/web/api/MemberApiController.java
@@ -1,0 +1,40 @@
+package dev.chan.orderpaymentservice.web.api;
+
+import dev.chan.orderpaymentservice.application.member.GetMemberUseCase;
+import dev.chan.orderpaymentservice.application.member.dto.MemberDetail;
+import dev.chan.orderpaymentservice.common.ApiResponse;
+import dev.chan.orderpaymentservice.common.UnauthorizedException;
+import dev.chan.orderpaymentservice.domain.member.MemberError;
+import dev.chan.orderpaymentservice.web.dto.LoginSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+public class MemberApiController {
+
+    private final GetMemberUseCase getMemberUseCase;
+
+    /**
+     * 회원 조회 API
+     * @return
+     */
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MemberDetail>> getMember(
+            @SessionAttribute(value = "LOGIN_MEMBER", required = false) LoginSession loginSession)
+    {
+        if (loginSession == null) {
+            throw new UnauthorizedException(MemberError.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        MemberDetail memberDetail = getMemberUseCase.handle(loginSession.memberId());
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(memberDetail));
+    }
+
+}

--- a/src/main/java/dev/chan/orderpaymentservice/web/dto/LoginSession.java
+++ b/src/main/java/dev/chan/orderpaymentservice/web/dto/LoginSession.java
@@ -1,8 +1,15 @@
 package dev.chan.orderpaymentservice.web.dto;
 
-public record LoginSession(long memberId, String email, String name) {
+import dev.chan.orderpaymentservice.common.UnauthorizedException;
+import dev.chan.orderpaymentservice.domain.member.MemberError;
 
-    public static Object of(long memberId, String email, String name) {
+public record LoginSession(long memberId, String email, String name) {
+    public LoginSession {
+        if(memberId <= 0) {
+            throw new UnauthorizedException(MemberError.INVALID_SESSION, "memberId must be positive.");
+        }
+    }
+    public static LoginSession of(long memberId, String email, String name) {
         return new LoginSession(memberId, email, name);
     }
 }

--- a/src/test/java/dev/chan/orderpaymentservice/application/LoginUseCaseTest.java
+++ b/src/test/java/dev/chan/orderpaymentservice/application/LoginUseCaseTest.java
@@ -93,7 +93,7 @@ class LoginUseCaseTest {
         //when & then
         assertThatThrownBy(() -> sut.handle(cmd))
                 .isInstanceOf(PolicyViolationException.class)
-                .extracting("errorCode").isEqualTo(MemberError.AUTHENTICATION_FAIL);
+                .extracting("errorCode").isEqualTo(MemberError.PASSWORD_MISMATCH);
 
         verify(memberRepository, times(1)).findByEmail(email);
         verifyNoMoreInteractions(memberRepository);
@@ -127,7 +127,7 @@ class LoginUseCaseTest {
         //when & then
         assertThatThrownBy(()-> sut.handle(cmd)).isInstanceOf(PolicyViolationException.class)
                 .extracting("errorCode")
-                .isEqualTo(MemberError.AUTHENTICATION_FAIL);
+                .isEqualTo(MemberError.PASSWORD_MISMATCH);
 
         verify(memberRepository, times(1)).findByEmail(email);
         verifyNoMoreInteractions(memberRepository);

--- a/src/test/java/dev/chan/orderpaymentservice/application/member/GetMemberUseCaseTest.java
+++ b/src/test/java/dev/chan/orderpaymentservice/application/member/GetMemberUseCaseTest.java
@@ -1,0 +1,87 @@
+package dev.chan.orderpaymentservice.application.member;
+
+import dev.chan.orderpaymentservice.application.member.dto.MemberDetail;
+import dev.chan.orderpaymentservice.common.NotFoundException;
+import dev.chan.orderpaymentservice.domain.member.Member;
+import dev.chan.orderpaymentservice.domain.member.MemberError;
+import dev.chan.orderpaymentservice.domain.member.MemberMother;
+import dev.chan.orderpaymentservice.domain.member.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GetMemberUseCaseTest {
+
+    @InjectMocks
+    GetMemberUseCase sut;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    /**
+     * 회원 조회 성공 (해피 패스)
+     *
+     * 설명: 회원 조회 성공 동작을 테스트
+     *
+     * 테스트 목적:
+     * - 회원 조회 성공시 조회된 회원의 회원 정보가 올바른지 검증합니다.
+     *
+     * 검증 포인트:
+     * 1. 회원 조회 성공시 조회 결과와 회원의 필드 데이터가 일치해야합니다.
+     * 2. 회원 조회로직 실행시 memberRepository 에서 회원 정보를 1회만 읽어옵니다.
+     */
+    @Test
+    void 회원조회시_DB에서_회원정보를_조회해서_반환한다() {
+        //given
+        long memberId = 1L;
+        Member member = MemberMother.newMember();
+        doReturn(Optional.of(member)).when(memberRepository).findById(memberId);
+
+        //when
+        MemberDetail result = sut.handle(memberId);
+
+        //then
+        verify(memberRepository).findById(memberId);
+        assertThat(result.email()).isEqualTo(member.getEmail());
+        assertThat(result.name()).isEqualTo(member.getName());
+        assertThat(result.phone()).isEqualTo(member.getPhone());
+
+    }
+    /**
+     * 회원 조회 실패 테스트 (언해피 패스)
+     *
+     * 설명: 회원 정보 조회 실패시 동작 테스트
+     *
+     * 테스트 목적:
+     * - 회원정보 조회 실패시 예외 처리를 테스트합니다.
+     *
+     * 검증 포인트:
+     * 1. 조회된 회원이 없을 경우 NotFoundException을 던집니다.
+     * 2. NotFoundException의 에러코드는 필드가 MEMBER_NOT_FOUND 인지 검증합니다.
+     *
+     */
+    @Test
+    void 회원조회시_조회결과가없으면_NotFound예외를_던지고_회원조회에_실패한다() {
+        //given
+        long memberId = 1L;
+        doReturn(Optional.empty()).when(memberRepository).findById(memberId);
+
+        //when & then
+        assertThatThrownBy(()-> sut.handle(memberId))
+                .isInstanceOf(NotFoundException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberError.MEMBER_NOT_FOUND);
+
+    }
+
+}

--- a/src/test/java/dev/chan/orderpaymentservice/domain/member/MemberMother.java
+++ b/src/test/java/dev/chan/orderpaymentservice/domain/member/MemberMother.java
@@ -14,4 +14,9 @@ public class MemberMother {
     public static Member withEmailAndPassword(String email, String password) {
         return Member.of(email, password, NAME, PHONE);
     }
+
+    public static Member newMember() {
+        return Member.of(EMAIL,PASSWORD,NAME,PHONE);
+
+    }
 }

--- a/src/test/java/dev/chan/orderpaymentservice/web/api/MemberApiControllerTest.java
+++ b/src/test/java/dev/chan/orderpaymentservice/web/api/MemberApiControllerTest.java
@@ -1,0 +1,81 @@
+package dev.chan.orderpaymentservice.web.api;
+
+import dev.chan.orderpaymentservice.application.member.GetMemberUseCase;
+import dev.chan.orderpaymentservice.application.member.dto.MemberDetail;
+import dev.chan.orderpaymentservice.domain.member.MemberError;
+import dev.chan.orderpaymentservice.web.dto.LoginSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class MemberApiControllerTest {
+
+    @InjectMocks
+    MemberApiController sut;
+
+    @Mock
+    GetMemberUseCase getMemberUseCase;
+
+    MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean bean = new LocalValidatorFactoryBean();
+        mvc = MockMvcBuilders.standaloneSetup(sut)
+                .setControllerAdvice(new ApiExceptionHandler())
+                .setValidator(bean)
+                .build();
+
+    }
+
+    @Test
+    void GET_회원조회요청시_세션있으면_200응답및_회원정보를_반환한다() throws Exception {
+        //given
+        long memberId = 1L;
+        String email = "email";
+        String name = "name";
+        MemberDetail memberDetail = new MemberDetail(email, name, "01011112222");
+        doReturn(memberDetail).when(getMemberUseCase).handle(memberId);
+
+        //when & then
+        mvc.perform(get("/api/v1/members/me")
+                    .sessionAttr("LOGIN_MEMBER", LoginSession.of(memberId,email,name))
+                    .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.email").value(email))
+                .andExpect(jsonPath("$.data.name").value(name));
+
+        verify(getMemberUseCase, times(1)).handle(memberId);
+    }
+
+    @Test
+    void GET_회원조회시_세션없으면_401응답및_에러정보를_반환한다() throws Exception {
+        //given
+        //when && then
+        mvc.perform(get("/api/v1/members/me")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.status").value(MemberError.UNAUTHORIZED.status().value()))
+                .andExpect(jsonPath("$.error.code").value(MemberError.UNAUTHORIZED.code()));
+
+        then(getMemberUseCase).shouldHaveNoInteractions();
+    }
+
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #17 

---

## 📝 작업 내용
> 회원 조회 API 구현 및 테스트 
- 회원 조회 Controller, usecse, repository 구현  
- 회원 조회 usecase, controller 단위테스트(실패, 성공 케이스) 구현 
- 단순 조회로직이므로 레파지토리에 대한 테스트와 전체 통합테스트는 작성하지 않았습니다. 추후 복잡도가 올라가면 추가 예정입니다. 
- 공통 예외 `UnauthorizedException` 추가 : 회원 로그인 후에만 회원 정보 조회가 가능하므로 Controller에서 session 을 확인해 로그인 여부를 확인하는 로직이 추가되었습니다. 인증 실패시 `UnauthorizedException`이 발생하며, 이에대한 처리는 `ApiExceptionHandler`에서 처리합니다. 
---

## 🔍 추가 고려 사항 (추후 PR 예정)
- Login 변경시 인증 로직 수정 예정 (Springsecurity 활용한 인증 로직 수정)
- 추후 메시지 소스및 국제화 서비스 추가 예정 (우선순위 매우낮음)
